### PR TITLE
DDP/Catalyst ID fetch duplicate fix

### DIFF
--- a/curriculum_training.py
+++ b/curriculum_training.py
@@ -192,7 +192,13 @@ class CustomRunner(dl.Runner):
         )
 
         tsampler = (
-            DistributedSamplerWrapper(DBBatchSampler(tdataset, batch_size=1))
+            DistributedSamplerWrapper(DBBatchSampler(
+                tdataset,
+                batch_size=1
+                num_replicas=1,
+                rank=0,   #    one of these lines 
+                seed=0,   #    is the fix
+            ))
             if self.engine.is_ddp
             else DBBatchSampler(tdataset, batch_size=1)
         )

--- a/curriculum_training.py
+++ b/curriculum_training.py
@@ -30,13 +30,18 @@ from torch.utils.data import DataLoader, Dataset, DistributedSampler
 
 from dice import faster_dice, DiceLoss
 from meshnet import enMesh_checkpoint, enMesh
-from mongoslabs.gencoords import CoordsGenerator
 
-from mongoslabs.mongoloader import (
+from mindfultensors.gencoords import CoordsGenerator
+from mindfultensors.utils import (
+    unit_interval_normalize,
+    qnormalize,
+    DBBatchSampler,
+)
+
+from mindfultensors.mongoloader import (
     create_client,
     collate_subcubes,
     mcollate,
-    MBatchSampler,
     MongoDataset,
     MongoClient,
     mtransform,
@@ -187,9 +192,9 @@ class CustomRunner(dl.Runner):
         )
 
         tsampler = (
-            DistributedSamplerWrapper(MBatchSampler(tdataset, batch_size=1))
+            DistributedSamplerWrapper(DBBatchSampler(tdataset, batch_size=1))
             if self.engine.is_ddp
-            else MBatchSampler(tdataset, batch_size=1)
+            else DBBatchSampler(tdataset, batch_size=1)
         )
 
         tdataloader = BatchPrefetchLoaderWrapper(
@@ -217,9 +222,9 @@ class CustomRunner(dl.Runner):
             fields=VIEWFIELDS,
         )
         vsampler = (
-            DistributedSamplerWrapper(MBatchSampler(vdataset, batch_size=1))
+            DistributedSamplerWrapper(DBBatchSampler(vdataset, batch_size=1))
             if self.engine.is_ddp
-            else MBatchSampler(vdataset, batch_size=1)
+            else DBBatchSampler(vdataset, batch_size=1)
         )
         vdataloader = BatchPrefetchLoaderWrapper(
             DataLoader(


### PR DESCRIPTION
This is a draft PR to replace mongoslabs imports to mindful tensors

Ultimately, the goal is to fix the DDP + Catalyst issue with repeated index fetches across parallel training processes

todo:
1. Test mindfultensor imports
2. Update vsampler to fix sampler seed
3. Test that there are no duplicate ids across training processes, and the full range of ids are covered